### PR TITLE
Introduce `rust-toolchain.toml`

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.59.0"
+channel = "stable"
 components = ["rustfmt", "rustc-dev"]
 targets = ["wasm32-unknown-unknown"]
 profile = "minimal"


### PR DESCRIPTION
We don't need nightly for `graph-ixi`, so let's override local Rust configuration with a `rust-toolchain.toml`.