### PR TITLE
New `common/build.rs` to automatically resync GraphQL schema

### DIFF
--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -20,3 +20,6 @@ serde_json = "1.0.78"
 serde_yaml = "0.8.21"
 tokio = { version = "1.14.0", features = ["full"] }
 tracing = "0.1.29"
+
+[build-dependencies]
+reqwest = { version = "0.11", features = ["blocking"] }

--- a/common/build.rs
+++ b/common/build.rs
@@ -1,0 +1,11 @@
+const INDEXER_SCHEMA_URL: &str = "https://raw.githubusercontent.com/graphprotocol/graph-node/master/server/index-node/src/schema.graphql";
+
+fn main() {
+    println!("cargo:rerun-if-changed=graphql/touch-this-file-to-refetch-schema");
+    let indexer_schema = reqwest::blocking::get(INDEXER_SCHEMA_URL)
+        .expect("Failed to fetch indexer schema")
+        .text()
+        .unwrap();
+
+    std::fs::write("graphql/indexer/schema.gql", indexer_schema).unwrap();
+}

--- a/common/graphql/indexer/schema.gql
+++ b/common/graphql/indexer/schema.gql
@@ -1,13 +1,50 @@
 scalar BigInt
 scalar Boolean
 scalar Bytes
+scalar ID
+scalar Int
 scalar String
 
+# An opaque object type. Note that this is equivalent to a JSON object, rather
+# than a generic JSON value; as such it cannot be e.g. a string or an integer.
+scalar JSONObject
+# A string in the format of `YYYY-MM-DD`. This is the standard adopted by
+# RFC3339, which is equivalent to the "ISO 8601 extended format".
+# See also:
+# - https://datatracker.ietf.org/doc/html/rfc3339#section-5.6
+# - https://en.wikipedia.org/wiki/ISO_8601#Calendar_dates
+scalar Date
+
 type Query {
+  indexingStatusForCurrentVersion(subgraphName: String!): SubgraphIndexingStatus
+  indexingStatusForPendingVersion(subgraphName: String!): SubgraphIndexingStatus
+  indexingStatusesForSubgraphName(
+    subgraphName: String!
+  ): [SubgraphIndexingStatus!]!
   indexingStatuses(subgraphs: [String!]): [SubgraphIndexingStatus!]!
+  proofOfIndexing(
+    subgraph: String!
+    blockNumber: Int!
+    blockHash: Bytes!
+    indexer: Bytes
+  ): Bytes
+  """
+  Proofs of indexing for several deployments and blocks that can be shared and
+  compared in public without revealing the _actual_ proof of indexing that every
+  indexer has in their database
+  """
   publicProofsOfIndexing(
     requests: [PublicProofOfIndexingRequest!]!
   ): [PublicProofOfIndexingResult!]!
+  subgraphFeatures(subgraphId: String!): SubgraphFeatures!
+  entityChangesInBlock(subgraphId: String!, blockNumber: Int!): EntityChanges!
+  blockData(network: String!, blockHash: Bytes!): JSONObject
+  blockHashFromNumber(network: String!, blockNumber: Int!): Bytes
+  cachedEthereumCalls(
+    network: String!
+    blockHash: Bytes!
+  ): [CachedEthereumCall!]
+  apiVersions(subgraphId: String!): [ApiVersion!]!
 }
 
 type SubgraphIndexingStatus {
@@ -33,7 +70,7 @@ type SubgraphIndexingStatus {
 interface ChainIndexingStatus {
   network: String!
   chainHeadBlock: Block
-  earliestBlock: Block
+  earliestBlock: EarliestBlock
   latestBlock: Block
   lastHealthyBlock: Block
 }
@@ -41,13 +78,33 @@ interface ChainIndexingStatus {
 type EthereumIndexingStatus implements ChainIndexingStatus {
   network: String!
   chainHeadBlock: Block
-  earliestBlock: Block
+  earliestBlock: EarliestBlock
   latestBlock: Block
   lastHealthyBlock: Block
 }
 
+type EntityChanges {
+  updates: [EntityTypeUpdates!]!
+  deletions: [EntityTypeDeletions!]!
+}
+
+type EntityTypeUpdates {
+  type: String!
+  entities: [JSONObject!]!
+}
+
+type EntityTypeDeletions {
+  type: String!
+  entities: [ID!]!
+}
+
 type Block {
   hash: Bytes!
+  number: BigInt!
+}
+
+type EarliestBlock {
+  hash: Bytes! @deprecated(reason: "hash will always be reported as 0x0.")
   number: BigInt!
 }
 
@@ -71,6 +128,36 @@ enum Health {
   failed
 }
 
+type CachedEthereumCall {
+  idHash: Bytes!
+  block: Block!
+  contractAddress: Bytes!
+  returnValue: Bytes!
+}
+
+type SubgraphFeatures {
+  features: [Feature!]!
+  errors: [String!]!
+  network: String
+}
+
+enum Feature {
+  nonFatalErrors
+  grafting
+  fullTextSearch
+  ipfsOnEthereumContracts
+}
+
+input BlockInput {
+  hash: Bytes!
+  number: BigInt!
+}
+
+input ProofOfIndexingRequest {
+  deployment: String!
+  block: BlockInput!
+}
+
 input PublicProofOfIndexingRequest {
   deployment: String!
   blockNumber: BigInt!
@@ -84,5 +171,19 @@ type PartialBlock {
 type PublicProofOfIndexingResult {
   deployment: String!
   block: PartialBlock!
+  proofOfIndexing: Bytes!
+}
+
+type ProofOfIndexingResult {
+  deployment: String!
+  block: Block!
+  "There may not be a proof of indexing available for the deployment and block"
   proofOfIndexing: Bytes
+}
+
+type ApiVersion {
+  """
+  Version number in SemVer format
+  """
+  version: String!
 }

--- a/common/graphql/touch-this-file-to-refetch-schema
+++ b/common/graphql/touch-this-file-to-refetch-schema
@@ -1,0 +1,2 @@
+Touching this file will modify its mtime, triggering the re-download of the
+GraphQL schema file.

--- a/common/src/indexer/real_indexer.rs
+++ b/common/src/indexer/real_indexer.rs
@@ -99,18 +99,7 @@ impl TryInto<ProofOfIndexing<RealIndexer>>
                     .hash
                     .and_then(|hash| hash.as_str().try_into().ok()),
             },
-            proof_of_indexing: self
-                .1
-                .proof_of_indexing
-                .ok_or_else(|| {
-                    anyhow!(
-                        "no proof of indexing available for {} at block #{}",
-                        self.1.deployment,
-                        self.1.block.number
-                    )
-                })?
-                .as_str()
-                .try_into()?,
+            proof_of_indexing: self.1.proof_of_indexing.as_str().try_into()?,
         })
     }
 }

--- a/scripts/sync-schemas.sh
+++ b/scripts/sync-schemas.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-set -e
-set -x
-
-SCRIPT_DIR=$(dirname $0)
-
-cd "$SCRIPT_DIR/../api-server/"
-cargo run --bin sync-schemas


### PR DESCRIPTION
The current mechanism to sync the GraphQL schema with the upstream version seems broken. I wrote a new `common/build.rs` that fetches the file from the `graph-node` repository. We'll still leave the artifact checked into the repository, and we'll manually re-trigger the build script when necessary.