### PR TITLE
Add interceptors to test config

### DIFF
--- a/backend/crates/common/src/bisect.rs
+++ b/backend/crates/common/src/bisect.rs
@@ -1,20 +1,14 @@
-use crate::prelude::{DivergingBlock as DivergentBlock, Indexer, ProofOfIndexing};
+use crate::prelude::{DivergingBlock as DivergentBlock, ProofOfIndexing};
 use futures::Future;
 use tracing::info;
 
-pub struct DivergingBlock<I>
-where
-    I: Indexer,
-{
-    pub poi1: ProofOfIndexing<I>,
-    pub poi2: ProofOfIndexing<I>,
+pub struct DivergingBlock {
+    pub poi1: ProofOfIndexing,
+    pub poi2: ProofOfIndexing,
 }
 
-impl<I> From<DivergingBlock<I>> for DivergentBlock
-where
-    I: Indexer,
-{
-    fn from(other: DivergingBlock<I>) -> DivergentBlock {
+impl From<DivergingBlock> for DivergentBlock {
+    fn from(other: DivergingBlock) -> DivergentBlock {
         Self {
             block: other.poi1.block,
             proof_of_indexing1: other.poi1.proof_of_indexing,
@@ -23,28 +17,24 @@ where
     }
 }
 
-pub enum BisectDecision<I>
-where
-    I: Indexer,
-{
+pub enum BisectDecision {
     Good,
     Bad {
-        poi1: ProofOfIndexing<I>,
-        poi2: ProofOfIndexing<I>,
+        poi1: ProofOfIndexing,
+        poi2: ProofOfIndexing,
     },
 }
 
-pub async fn bisect_blocks<C, F, Out, I>(
+pub async fn bisect_blocks<C, F, Out>(
     bisection_id: String,
     context: C,
-    mut bad: DivergingBlock<I>,
+    mut bad: DivergingBlock,
     test_fn: F,
-) -> Result<DivergingBlock<I>, anyhow::Error>
+) -> Result<DivergingBlock, anyhow::Error>
 where
     C: Clone,
     F: Fn(String, C, u64) -> Out,
-    Out: Future<Output = Result<BisectDecision<I>, anyhow::Error>>,
-    I: Indexer,
+    Out: Future<Output = Result<BisectDecision, anyhow::Error>>,
 {
     info!(%bisection_id, bad = %bad.poi1.block.number, "Bisect start");
 

--- a/backend/crates/common/src/config.rs
+++ b/backend/crates/common/src/config.rs
@@ -17,9 +17,24 @@ pub struct IndexerUrls {
 }
 
 #[derive(Clone, Debug, Deserialize)]
-pub struct EnvironmentConfig {
+pub struct IndexerConfig {
     pub id: String,
     pub urls: IndexerUrls,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct InterceptorConfig {
+    pub id: String,
+    pub target: String,
+    pub poi_byte: u8,
+}
+
+// enumify EnvironmentConfig, with a variant like the existing one and a new one called `InterceptorConfig`
+#[derive(Clone, Debug, Deserialize)]
+#[serde(tag = "type")]
+pub enum EnvironmentConfig {
+    Indexer(IndexerConfig),
+    Interceptor(InterceptorConfig),
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/backend/crates/common/src/db/proofs_of_indexing.rs
+++ b/backend/crates/common/src/db/proofs_of_indexing.rs
@@ -4,20 +4,19 @@ use futures::{FutureExt, Stream, StreamExt, TryFutureExt};
 use futures_retry::{FutureRetry, RetryPolicy};
 use tracing::warn;
 
-use crate::{indexer::Indexer, types};
+use crate::types;
 
 use super::{PoiLiveness, Store};
 
 /// Write any POIs that we receive to the database.
-pub fn write<S, I>(store: Store, proofs_of_indexing: S)
+pub fn write<S>(store: Store, proofs_of_indexing: S)
 where
-    S: Stream<Item = types::ProofOfIndexing<I>> + Send + 'static,
-    I: Indexer + 'static,
+    S: Stream<Item = types::ProofOfIndexing> + Send + 'static,
 {
     tokio::spawn(async move {
         proofs_of_indexing
             .ready_chunks(100)
-            .for_each(move |chunk: Vec<types::ProofOfIndexing<I>>| {
+            .for_each(move |chunk: Vec<types::ProofOfIndexing>| {
                 let store = store.clone();
                 let mut consecutive_errors = 0;
 
@@ -49,10 +48,9 @@ where
 }
 
 /// Write any POI cross-check reports that we receive to the database.
-pub fn write_reports<S, I>(_store: Store, _reports: S)
+pub fn write_reports<S>(_store: Store, _reports: S)
 where
-    S: Stream<Item = types::POICrossCheckReport<I>> + Send + 'static,
-    I: Indexer + Send + Sync + 'static,
+    S: Stream<Item = types::POICrossCheckReport> + Send + 'static,
 {
     // TODO writing cross check reports to the database not implemented
     // tokio::spawn(async move {

--- a/backend/crates/common/src/db/tests.rs
+++ b/backend/crates/common/src/db/tests.rs
@@ -1,9 +1,6 @@
 use std::collections::BTreeSet;
 
-use crate::{
-    db::{diesel_queries, PoiLiveness, Store},
-    PrometheusMetrics,
-};
+use crate::db::{diesel_queries, PoiLiveness, Store};
 use diesel::Connection;
 
 use crate::tests::{fast_rng, gen::gen_indexers};
@@ -16,13 +13,9 @@ fn test_db_url() -> String {
 async fn poi_db_roundtrip() {
     let mut rng = fast_rng(0);
     let indexers = gen_indexers(&mut rng, 100);
-    let metrics =
-        PrometheusMetrics::new(prometheus_exporter::prometheus::default_registry().clone());
 
-    let indexing_statuses =
-        crate::indexing_statuses::query_indexing_statuses(&metrics, indexers).await;
-    let pois =
-        crate::proofs_of_indexing::query_proofs_of_indexing(&metrics, indexing_statuses).await;
+    let indexing_statuses = crate::indexing_statuses::query_indexing_statuses(indexers).await;
+    let pois = crate::proofs_of_indexing::query_proofs_of_indexing(indexing_statuses).await;
 
     let store = Store::new(&test_db_url()).unwrap();
     let mut conn = store.test_conn();

--- a/backend/crates/common/src/db/tests.rs
+++ b/backend/crates/common/src/db/tests.rs
@@ -2,7 +2,6 @@ use std::collections::BTreeSet;
 
 use crate::{
     db::{diesel_queries, PoiLiveness, Store},
-    indexer::Indexer,
     PrometheusMetrics,
 };
 use diesel::Connection;

--- a/backend/crates/common/src/indexer/interceptor.rs
+++ b/backend/crates/common/src/indexer/interceptor.rs
@@ -1,0 +1,72 @@
+use std::sync::Arc;
+
+use crate::indexer::types::Indexer;
+use crate::prelude::Bytes32;
+use crate::types::{IndexingStatus, POIRequest, ProofOfIndexing};
+use async_trait::async_trait;
+
+/// Pretends to be an indexer by routing requests a `RealIndexer` and then intercepting the
+/// responses to generate diverging PoIs. The divergent pois will consist of a repetition of
+/// `poi_bit`.
+#[derive(Debug)]
+pub struct IndexerInterceptor {
+    target: Arc<dyn Indexer>,
+    id: String,
+    poi_byte: u8,
+}
+
+impl IndexerInterceptor {
+    pub fn new(id: String, target: Arc<dyn Indexer>, poi_byte: u8) -> Self {
+        Self {
+            id,
+            target,
+            poi_byte,
+        }
+    }
+}
+
+#[async_trait]
+
+impl Indexer for IndexerInterceptor {
+    fn id(&self) -> &str {
+        &self.id
+    }
+
+    fn address(&self) -> Option<&[u8]> {
+        None
+    }
+
+    async fn indexing_statuses(self: Arc<Self>) -> Result<Vec<IndexingStatus>, anyhow::Error> {
+        let statuses = self.target.clone().indexing_statuses().await?;
+        let hijacked_statuses = statuses
+            .into_iter()
+            .map(|status| IndexingStatus {
+                indexer: self.clone(),
+                deployment: status.deployment,
+                network: status.network,
+                latest_block: status.latest_block,
+            })
+            .collect();
+        Ok(hijacked_statuses)
+    }
+
+    async fn proofs_of_indexing(
+        self: Arc<Self>,
+        requests: Vec<POIRequest>,
+    ) -> Result<Vec<ProofOfIndexing>, anyhow::Error> {
+        let pois = self.target.clone().proofs_of_indexing(requests).await?;
+
+        Ok(pois
+            .into_iter()
+            .map(|poi| {
+                let divergent_poi = Bytes32([self.poi_byte; 32]);
+                ProofOfIndexing {
+                    indexer: self.clone(),
+                    deployment: poi.deployment,
+                    block: poi.block,
+                    proof_of_indexing: divergent_poi,
+                }
+            })
+            .collect())
+    }
+}

--- a/backend/crates/common/src/indexer/mod.rs
+++ b/backend/crates/common/src/indexer/mod.rs
@@ -1,5 +1,8 @@
 mod real_indexer;
 mod types;
 
+// A indexer interceptor, for test configs only.
+pub mod interceptor;
+
 pub use self::real_indexer::*;
 pub use self::types::*;

--- a/backend/crates/common/src/indexer/real_indexer.rs
+++ b/backend/crates/common/src/indexer/real_indexer.rs
@@ -8,8 +8,8 @@ use tracing::*;
 use crate::{
     config::IndexerUrls,
     prelude::IndexerConfig,
+    prometheus_metrics::metrics,
     types::{BlockPointer, IndexingStatus, POIRequest, ProofOfIndexing, SubgraphDeployment},
-    PrometheusMetrics,
 };
 
 use super::Indexer;
@@ -187,7 +187,6 @@ impl Indexer for RealIndexer {
 
     async fn proofs_of_indexing(
         self: Arc<Self>,
-        metrics: &PrometheusMetrics,
         requests: Vec<POIRequest>,
     ) -> Result<Vec<ProofOfIndexing>, anyhow::Error> {
         let mut pois = vec![];
@@ -215,7 +214,7 @@ impl Indexer for RealIndexer {
 
             // Log any errors received for debugging
             if let Some(errors) = response.errors {
-                metrics
+                metrics()
                     .public_proofs_of_indexing_requests
                     .get_metric_with_label_values(&[self.id(), "0"])
                     .unwrap()
@@ -234,7 +233,7 @@ impl Indexer for RealIndexer {
             }
 
             if let Some(data) = response.data {
-                metrics
+                metrics()
                     .public_proofs_of_indexing_requests
                     .get_metric_with_label_values(&[self.id(), "1"])
                     .unwrap()

--- a/backend/crates/common/src/indexer/types.rs
+++ b/backend/crates/common/src/indexer/types.rs
@@ -1,4 +1,5 @@
-use core::hash::Hash;
+use std::sync::Arc;
+use std::{fmt::Debug, hash::Hash};
 
 use anyhow::anyhow;
 use async_trait::async_trait;
@@ -9,27 +10,42 @@ use crate::{
 };
 
 #[async_trait]
-pub trait Indexer: Clone + Sized + Eq + Send + Sync + Hash + Ord + Send + Sync {
+pub trait Indexer: Send + Sync + Debug {
+    /// Uniquely identifies the indexer. This is relied on for the `Hash` and `Eq` impls.
     fn id(&self) -> &str;
     fn address(&self) -> Option<&[u8]>;
 
-    async fn indexing_statuses(self) -> Result<Vec<IndexingStatus<Self>>, anyhow::Error>;
+    async fn indexing_statuses(self: Arc<Self>) -> Result<Vec<IndexingStatus>, anyhow::Error>;
 
     async fn proofs_of_indexing(
-        self,
+        self: Arc<Self>,
         metrics: &PrometheusMetrics,
         requests: Vec<POIRequest>,
-    ) -> Result<Vec<ProofOfIndexing<Self>>, anyhow::Error>;
+    ) -> Result<Vec<ProofOfIndexing>, anyhow::Error>;
 
     /// Convenience wrapper around calling `proofs_of_indexing` for a single POI.
     async fn proof_of_indexing(
-        self,
+        self: Arc<Self>,
         metrics: &PrometheusMetrics,
         request: POIRequest,
-    ) -> Result<ProofOfIndexing<Self>, anyhow::Error> {
+    ) -> Result<ProofOfIndexing, anyhow::Error> {
         let mut results = self.proofs_of_indexing(metrics, vec![request]).await?;
         results
             .pop()
             .ok_or_else(|| anyhow!("no proof of indexing returned"))
+    }
+}
+
+impl PartialEq for dyn Indexer {
+    fn eq(&self, other: &Self) -> bool {
+        self.id() == other.id()
+    }
+}
+
+impl Eq for dyn Indexer {}
+
+impl Hash for dyn Indexer {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.id().hash(state)
     }
 }

--- a/backend/crates/common/src/indexing_statuses/query.rs
+++ b/backend/crates/common/src/indexing_statuses/query.rs
@@ -1,17 +1,14 @@
 use std::sync::Arc;
 
 use crate::prelude::{Indexer, IndexingStatus};
-use crate::PrometheusMetrics;
+use crate::prometheus_metrics::metrics;
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
 use tracing::*;
 
 /// Queries all `indexingStatuses` for all `indexers`.
 #[instrument(skip_all)]
-pub async fn query_indexing_statuses(
-    metrics: &PrometheusMetrics,
-    indexers: Vec<Arc<dyn Indexer>>,
-) -> Vec<IndexingStatus> {
+pub async fn query_indexing_statuses(indexers: Vec<Arc<dyn Indexer>>) -> Vec<IndexingStatus> {
     let indexer_count = indexers.len();
     info!(indexers = indexer_count, "Querying indexing statuses...");
 
@@ -27,14 +24,14 @@ pub async fn query_indexing_statuses(
     while let Some((indexer, query_res)) = futures.next().await {
         if query_res.is_ok() {
             query_successes += 1;
-            metrics
+            metrics()
                 .indexing_statuses_requests
                 .get_metric_with_label_values(&[indexer.id(), "1"])
                 .unwrap()
                 .inc();
         } else {
             query_failures += 1;
-            metrics
+            metrics()
                 .indexing_statuses_requests
                 .get_metric_with_label_values(&[indexer.id(), "0"])
                 .unwrap()

--- a/backend/crates/common/src/modes/testing.rs
+++ b/backend/crates/common/src/modes/testing.rs
@@ -1,9 +1,45 @@
+use std::sync::Arc;
+
 use tracing::*;
 
 use crate::config::TestingConfig;
-use crate::indexer::RealIndexer;
+use crate::indexer::interceptor::IndexerInterceptor;
+use crate::indexer::{Indexer, RealIndexer};
+use crate::prelude::EnvironmentConfig;
 
 #[instrument]
-pub fn testing_indexers(config: TestingConfig) -> Vec<RealIndexer> {
-    config.environments.iter().map(RealIndexer::new).collect()
+pub fn testing_indexers(config: TestingConfig) -> Vec<Arc<dyn Indexer>> {
+    let mut indexers: Vec<Arc<dyn Indexer>> = vec![];
+
+    // First, configure all the real indexers.
+    for config in &config.environments {
+        match config {
+            EnvironmentConfig::Indexer(config) => {
+                info!(indexer_id = %config.id, "Configuring indexer");
+                indexers.push(Arc::new(RealIndexer::new(config.clone())));
+            }
+            EnvironmentConfig::Interceptor(_) => {}
+        }
+    }
+
+    // Then, configure all the interceptors, referring to the real indexers by ID.
+    for config in config.environments {
+        match config {
+            EnvironmentConfig::Indexer(_config) => {}
+            EnvironmentConfig::Interceptor(config) => {
+                info!(interceptor_id = %config.id, "Configuring interceptor");
+                let target = indexers
+                    .iter()
+                    .find(|indexer| indexer.id() == config.target)
+                    .expect("interceptor target indexer not found");
+                indexers.push(Arc::new(IndexerInterceptor::new(
+                    config.id,
+                    target.clone(),
+                    config.poi_byte,
+                )));
+            }
+        }
+    }
+
+    indexers
 }

--- a/backend/crates/common/src/proofs_of_indexing/query.rs
+++ b/backend/crates/common/src/proofs_of_indexing/query.rs
@@ -1,4 +1,5 @@
 use std::collections::{hash_map::RandomState, HashMap, HashSet};
+use std::sync::Arc;
 
 use crate::prelude::{
     BlockPointer, Indexer, IndexingStatus, POIRequest, ProofOfIndexing, SubgraphDeployment,
@@ -8,20 +9,17 @@ use futures::stream::FuturesUnordered;
 use futures::StreamExt;
 use tracing::*;
 
-pub async fn query_proofs_of_indexing<I>(
+pub async fn query_proofs_of_indexing(
     metrics: &PrometheusMetrics,
-    indexing_statuses: Vec<IndexingStatus<I>>,
-) -> Vec<ProofOfIndexing<I>>
-where
-    I: Indexer,
-{
+    indexing_statuses: Vec<IndexingStatus>,
+) -> Vec<ProofOfIndexing> {
     info!("Query POIs for recent common blocks across indexers");
 
     // Identify all indexers
     let indexers = indexing_statuses
         .iter()
         .map(|status| status.indexer.clone())
-        .collect::<HashSet<I, RandomState>>();
+        .collect::<HashSet<_>>();
 
     // Identify all deployments
     let deployments: HashSet<SubgraphDeployment, RandomState> = HashSet::from_iter(
@@ -31,7 +29,7 @@ where
     );
 
     // Group indexing statuses by deployment
-    let statuses_by_deployment: HashMap<SubgraphDeployment, Vec<&IndexingStatus<I>>> =
+    let statuses_by_deployment: HashMap<SubgraphDeployment, Vec<&IndexingStatus>> =
         HashMap::from_iter(deployments.iter().map(|deployment| {
             (
                 deployment.clone(),
@@ -91,12 +89,12 @@ where
         .collect::<Vec<_>>()
 }
 
-fn skip_errors<I>(
-    result: (Result<Vec<ProofOfIndexing<I>>, anyhow::Error>, I),
-) -> Option<Vec<ProofOfIndexing<I>>>
-where
-    I: Indexer,
-{
+fn skip_errors(
+    result: (
+        Result<Vec<ProofOfIndexing>, anyhow::Error>,
+        Arc<dyn Indexer>,
+    ),
+) -> Option<Vec<ProofOfIndexing>> {
     match result.0 {
         Ok(pois) => {
             info!(

--- a/backend/crates/common/src/proofs_of_indexing/query.rs
+++ b/backend/crates/common/src/proofs_of_indexing/query.rs
@@ -4,13 +4,11 @@ use std::sync::Arc;
 use crate::prelude::{
     BlockPointer, Indexer, IndexingStatus, POIRequest, ProofOfIndexing, SubgraphDeployment,
 };
-use crate::PrometheusMetrics;
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
 use tracing::*;
 
 pub async fn query_proofs_of_indexing(
-    metrics: &PrometheusMetrics,
     indexing_statuses: Vec<IndexingStatus>,
 ) -> Vec<ProofOfIndexing> {
     info!("Query POIs for recent common blocks across indexers");
@@ -76,7 +74,7 @@ pub async fn query_proofs_of_indexing(
                 })
                 .collect::<Vec<_>>();
 
-            indexer.clone().proofs_of_indexing(&metrics, poi_requests)
+            indexer.clone().proofs_of_indexing(poi_requests)
         })
         .collect::<FuturesUnordered<_>>()
         .collect::<Vec<_>>()

--- a/backend/crates/common/src/tests/gen.rs
+++ b/backend/crates/common/src/tests/gen.rs
@@ -1,6 +1,9 @@
 use std::{iter::repeat_with, sync::Arc};
 
-use crate::prelude::{BlockPointer, Bytes32, SubgraphDeployment};
+use crate::{
+    indexer::Indexer,
+    prelude::{BlockPointer, Bytes32, SubgraphDeployment},
+};
 use rand::{distributions::Alphanumeric, seq::IteratorRandom, Rng};
 
 use super::mocks::{DeploymentDetails, MockIndexer, PartialProofOfIndexing};
@@ -54,7 +57,7 @@ where
         .collect()
 }
 
-pub fn gen_indexers<R>(mut rng: &mut R, max_indexers: usize) -> Vec<Arc<MockIndexer>>
+pub fn gen_indexers<R>(mut rng: &mut R, max_indexers: usize) -> Vec<Arc<dyn Indexer>>
 where
     R: Rng,
 {
@@ -95,8 +98,8 @@ where
             deployment_details,
             fail_indexing_statuses: rng.gen_bool(0.1),
             fail_proofs_of_indexing: rng.gen_bool(0.1),
-        })
+        }) as Arc<dyn Indexer>
     })
     .take(number_of_indexers)
-    .collect::<Vec<Arc<MockIndexer>>>()
+    .collect()
 }

--- a/backend/crates/common/src/tests/mocks.rs
+++ b/backend/crates/common/src/tests/mocks.rs
@@ -1,11 +1,7 @@
 use std::sync::Arc;
 
-use crate::{
-    prelude::{
-        BlockPointer, Bytes32, Indexer, IndexingStatus, POIRequest, ProofOfIndexing,
-        SubgraphDeployment,
-    },
-    PrometheusMetrics,
+use crate::prelude::{
+    BlockPointer, Bytes32, Indexer, IndexingStatus, POIRequest, ProofOfIndexing, SubgraphDeployment,
 };
 use anyhow::anyhow;
 use async_trait::async_trait;
@@ -56,7 +52,6 @@ impl Indexer for MockIndexer {
 
     async fn proofs_of_indexing(
         self: Arc<Self>,
-        _metrics: &PrometheusMetrics,
         requests: Vec<POIRequest>,
     ) -> Result<Vec<ProofOfIndexing>, anyhow::Error> {
         if self.fail_proofs_of_indexing {

--- a/backend/crates/common/src/tests/mocks.rs
+++ b/backend/crates/common/src/tests/mocks.rs
@@ -27,7 +27,7 @@ pub struct MockIndexer {
 }
 
 #[async_trait]
-impl Indexer for Arc<MockIndexer> {
+impl Indexer for MockIndexer {
     fn id(&self) -> &str {
         &self.id
     }
@@ -36,7 +36,7 @@ impl Indexer for Arc<MockIndexer> {
         None
     }
 
-    async fn indexing_statuses(self) -> Result<Vec<IndexingStatus<Self>>, anyhow::Error> {
+    async fn indexing_statuses(self: Arc<Self>) -> Result<Vec<IndexingStatus>, anyhow::Error> {
         if self.fail_indexing_statuses {
             Err(anyhow!("boo"))
         } else {
@@ -55,10 +55,10 @@ impl Indexer for Arc<MockIndexer> {
     }
 
     async fn proofs_of_indexing(
-        self,
+        self: Arc<Self>,
         _metrics: &PrometheusMetrics,
         requests: Vec<POIRequest>,
-    ) -> Result<Vec<ProofOfIndexing<Self>>, anyhow::Error> {
+    ) -> Result<Vec<ProofOfIndexing>, anyhow::Error> {
         if self.fail_proofs_of_indexing {
             Err(anyhow!("boo"))
         } else {

--- a/backend/crates/cross-checker/src/cross_checking.rs
+++ b/backend/crates/cross-checker/src/cross_checking.rs
@@ -9,12 +9,9 @@ use futures::{
     stream::FuturesUnordered,
     FutureExt, SinkExt, Stream, StreamExt,
 };
+use graphix_common::bisect::{bisect_blocks, BisectDecision, DivergingBlock};
 use graphix_common::prelude::{
     Indexer, POICrossCheckReport, POIRequest, ProofOfIndexing, SubgraphDeployment,
-};
-use graphix_common::{
-    bisect::{bisect_blocks, BisectDecision, DivergingBlock},
-    PrometheusMetrics,
 };
 use itertools::Itertools;
 use nanoid::nanoid;
@@ -187,9 +184,6 @@ async fn test_block_number(
     ctx: POIBisectContext,
     block_number: u64,
 ) -> Result<BisectDecision, anyhow::Error> {
-    let metrics =
-        PrometheusMetrics::new(prometheus_exporter::prometheus::default_registry().clone());
-
     debug!(
         %bisection_id,
         %block_number,
@@ -208,12 +202,8 @@ async fn test_block_number(
         block_number,
     };
 
-    let poi1 = indexer1
-        .proof_of_indexing(&metrics, request.clone())
-        .await?;
-    let poi2 = indexer2
-        .proof_of_indexing(&metrics, request.clone())
-        .await?;
+    let poi1 = indexer1.proof_of_indexing(request.clone()).await?;
+    let poi2 = indexer2.proof_of_indexing(request.clone()).await?;
 
     poi_broadcaster.send(poi1.clone()).await?;
     poi_broadcaster.send(poi2.clone()).await?;

--- a/backend/crates/cross-checker/src/main.rs
+++ b/backend/crates/cross-checker/src/main.rs
@@ -5,9 +5,7 @@ mod tests;
 
 use clap::Parser;
 use graphix_common::{db, modes, prelude::Config};
-use graphix_common::{
-    indexing_statuses, proofs_of_indexing, PrometheusExporter, PrometheusMetrics,
-};
+use graphix_common::{indexing_statuses, proofs_of_indexing, PrometheusExporter};
 use prometheus_exporter::prometheus;
 use std::path::PathBuf;
 use std::time::Duration;
@@ -36,17 +34,15 @@ async fn main() -> anyhow::Result<()> {
 
     // Prometheus metrics.
     let registry = prometheus::default_registry().clone();
-    let metrics = PrometheusMetrics::new(registry.clone());
     let _exporter = PrometheusExporter::start(9184, registry.clone()).unwrap();
 
     loop {
         info!("New main loop iteration");
 
-        let indexing_statuses =
-            indexing_statuses::query_indexing_statuses(&metrics, indexers.clone()).await;
+        let indexing_statuses = indexing_statuses::query_indexing_statuses(indexers.clone()).await;
 
         info!("Monitor proofs of indexing");
-        let pois = proofs_of_indexing::query_proofs_of_indexing(&metrics, indexing_statuses).await;
+        let pois = proofs_of_indexing::query_proofs_of_indexing(indexing_statuses).await;
 
         store.write_pois(&pois, db::PoiLiveness::Live)?;
 

--- a/backend/crates/cross-checker/src/tests/indexing_statuses.rs
+++ b/backend/crates/cross-checker/src/tests/indexing_statuses.rs
@@ -1,7 +1,5 @@
-use std::collections::BTreeSet;
-
 use futures::{future, stream::FuturesUnordered, StreamExt};
-use graphix_common::{prelude::Indexer, PrometheusMetrics};
+use graphix_common::prelude::IndexingStatus;
 
 use crate::indexing_statuses;
 
@@ -28,14 +26,13 @@ async fn indexing_statuses() {
             .await
             .into_iter()
             .flatten()
-            .collect::<BTreeSet<_>>();
+            .collect::<Vec<_>>();
 
-        let metrics =
-            PrometheusMetrics::new(prometheus_exporter::prometheus::default_registry().clone());
-        let queried_statuses = indexing_statuses::query_indexing_statuses(&metrics, indexers)
-            .await
-            .into_iter()
-            .collect();
+        let queried_statuses: Vec<IndexingStatus> =
+            indexing_statuses::query_indexing_statuses(indexers)
+                .await
+                .into_iter()
+                .collect();
 
         assert_eq!(expected_statuses, queried_statuses);
     }

--- a/backend/crates/cross-checker/src/tests/proofs_of_indexing.rs
+++ b/backend/crates/cross-checker/src/tests/proofs_of_indexing.rs
@@ -1,7 +1,4 @@
-use graphix_common::{
-    tests::{fast_rng, gen::gen_indexers},
-    PrometheusMetrics,
-};
+use graphix_common::tests::{fast_rng, gen::gen_indexers};
 use itertools::Itertools;
 use std::collections::BTreeSet;
 
@@ -15,11 +12,8 @@ async fn proofs_of_indexing() {
         let max_indexers = i;
         let indexers = gen_indexers(&mut rng, max_indexers as usize);
 
-        let metrics =
-            PrometheusMetrics::new(prometheus_exporter::prometheus::default_registry().clone());
-        let indexing_statuses =
-            indexing_statuses::query_indexing_statuses(&metrics, indexers).await;
-        let pois = proofs_of_indexing::query_proofs_of_indexing(&metrics, indexing_statuses);
+        let indexing_statuses = indexing_statuses::query_indexing_statuses(indexers).await;
+        let pois = proofs_of_indexing::query_proofs_of_indexing(indexing_statuses);
 
         let actual_pois = pois.await.into_iter().collect::<BTreeSet<_>>();
 

--- a/examples/testing.yml
+++ b/examples/testing.yml
@@ -2,9 +2,11 @@ testing:
   databaseUrl: postgres://localhost:5432/graphix
   environments:
     - id: indexer-1
+      type: Indexer
       urls:
         status: http://localhost:8103/graphql
     - id: indexer-2
+      type: Indexer
       urls:
         status: http://localhost:8203/graphql
     # - id: indexer-3

--- a/ops/compose/graphix/testnet-indexer.yml
+++ b/ops/compose/graphix/testnet-indexer.yml
@@ -3,6 +3,7 @@
 databaseUrl: postgres://graphix:password@postgres-graphix:5432/graphix
 environments:
   - id: testnet-indexer-03
+    type: Indexer
     urls:
       status: http://testnet-indexer-03-europe-cent.thegraph.com/status
 

--- a/ops/compose/graphix/two-empty-graph-nodes.yml
+++ b/ops/compose/graphix/two-empty-graph-nodes.yml
@@ -3,8 +3,10 @@
 databaseUrl: postgres://graphix:password@postgres-graphix:5432/graphix
 environments:
   - id: graph-node-1
+    type: Indexer
     urls:
       status: http://graph-node-1:8030/graphql
   - id: graph-node-2
+    type: Indexer
     urls:
       status: http://graph-node-2:8030/graphql

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.69.0"
+channel = "1.70.0"
 targets = ["wasm32-unknown-unknown"]
 profile = "default"


### PR DESCRIPTION
The goal of this PR is to add a way to generate PoIs divergences. That requires two indexer that index the same subgraph but with different PoIs. The approach in this PR is to add a way to configure indexer interceptors, as in the following config:
```
!testing

databaseUrl: postgresql://leoyvens:@localhost/graphix_testnet
environments:
  - id: testnet-indexer-03
    type: Indexer
    urls:
      status: https://testnet-indexer-03-europe-cent.thegraph.com/status
  - id: testnet-indexer-03-interceptor
    type: Interceptor
    target: testnet-indexer-03
    poi_byte: 255
```

The interceptor proxies all requests to the target indexer, but will modify the PoI to `[poi_byte; 32]`, therefore generating a divergence on all the subgraphs. This approach has the downside of generating more request traffic to the base indexer, which is not the fastest way to generate artificial divergences, but it has the advantage of being very robust to code changes.

This required refactoring from generics to `Arc<dyn Indexer>`, since now we need a heterogeneous collection of indexer types, a classic use case for trait objects. I felt the enum approach wouldn't work very well.