### PR TITLE
Refactor error handling again

### DIFF
--- a/backend/crates/common/src/indexer/interceptor.rs
+++ b/backend/crates/common/src/indexer/interceptor.rs
@@ -53,11 +53,10 @@ impl Indexer for IndexerInterceptor {
     async fn proofs_of_indexing(
         self: Arc<Self>,
         requests: Vec<POIRequest>,
-    ) -> Result<Vec<ProofOfIndexing>, anyhow::Error> {
-        let pois = self.target.clone().proofs_of_indexing(requests).await?;
+    ) -> Vec<ProofOfIndexing> {
+        let pois = self.target.clone().proofs_of_indexing(requests).await;
 
-        Ok(pois
-            .into_iter()
+        pois.into_iter()
             .map(|poi| {
                 let divergent_poi = Bytes32([self.poi_byte; 32]);
                 ProofOfIndexing {
@@ -67,6 +66,6 @@ impl Indexer for IndexerInterceptor {
                     proof_of_indexing: divergent_poi,
                 }
             })
-            .collect())
+            .collect()
     }
 }

--- a/backend/crates/common/src/indexer/real_indexer.rs
+++ b/backend/crates/common/src/indexer/real_indexer.rs
@@ -244,11 +244,7 @@ impl Indexer for RealIndexer {
                     .map(|e| e.message.clone())
                     .collect::<Vec<_>>()
                     .join(",");
-                warn!(
-                    id = %self.id(),
-                    %errors,
-                    "indexer returned POI errors"
-                );
+                return Err(anyhow!("indexer returned POI errors: {}", errors));
             }
 
             if let Some(data) = response.data {

--- a/backend/crates/common/src/indexer/types.rs
+++ b/backend/crates/common/src/indexer/types.rs
@@ -14,17 +14,15 @@ pub trait Indexer: Send + Sync + Debug {
 
     async fn indexing_statuses(self: Arc<Self>) -> Result<Vec<IndexingStatus>, anyhow::Error>;
 
-    async fn proofs_of_indexing(
-        self: Arc<Self>,
-        requests: Vec<POIRequest>,
-    ) -> Result<Vec<ProofOfIndexing>, anyhow::Error>;
+    async fn proofs_of_indexing(self: Arc<Self>, requests: Vec<POIRequest>)
+        -> Vec<ProofOfIndexing>;
 
     /// Convenience wrapper around calling `proofs_of_indexing` for a single POI.
     async fn proof_of_indexing(
         self: Arc<Self>,
         request: POIRequest,
     ) -> Result<ProofOfIndexing, anyhow::Error> {
-        let mut results = self.proofs_of_indexing(vec![request]).await?;
+        let mut results = self.proofs_of_indexing(vec![request]).await;
         results
             .pop()
             .ok_or_else(|| anyhow!("no proof of indexing returned"))

--- a/backend/crates/common/src/proofs_of_indexing/query.rs
+++ b/backend/crates/common/src/proofs_of_indexing/query.rs
@@ -1,8 +1,7 @@
 use std::collections::{hash_map::RandomState, HashMap, HashSet};
-use std::sync::Arc;
 
 use crate::prelude::{
-    BlockPointer, Indexer, IndexingStatus, POIRequest, ProofOfIndexing, SubgraphDeployment,
+    BlockPointer, IndexingStatus, POIRequest, ProofOfIndexing, SubgraphDeployment,
 };
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
@@ -80,33 +79,6 @@ pub async fn query_proofs_of_indexing(
         .collect::<Vec<_>>()
         .await
         .into_iter()
-        .zip(indexers.into_iter())
-        .into_iter()
-        .filter_map(skip_errors)
         .flatten()
         .collect::<Vec<_>>()
-}
-
-fn skip_errors(
-    result: (
-        Result<Vec<ProofOfIndexing>, anyhow::Error>,
-        Arc<dyn Indexer>,
-    ),
-) -> Option<Vec<ProofOfIndexing>> {
-    match result.0 {
-        Ok(pois) => {
-            info!(
-                id = %result.1.id(), pois = %pois.len(),
-                "Successfully queried POIs from indexer"
-            );
-            Some(pois)
-        }
-        Err(error) => {
-            warn!(
-                id = %result.1.id(), %error,
-                "Failed to query POIs from indexer"
-            );
-            None
-        }
-    }
 }

--- a/backend/crates/common/src/tests/gen.rs
+++ b/backend/crates/common/src/tests/gen.rs
@@ -97,7 +97,6 @@ where
             id,
             deployment_details,
             fail_indexing_statuses: rng.gen_bool(0.1),
-            fail_proofs_of_indexing: rng.gen_bool(0.1),
         }) as Arc<dyn Indexer>
     })
     .take(number_of_indexers)


### PR DESCRIPTION
Extract the code for each batch request into a function, changing the trait signature to be infallible.