### PR TITLE
Publish Docker images to GHCR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: full
+  REGISTRY: ghcr.io
 
 jobs:
   rustfmt:
@@ -27,48 +28,44 @@ jobs:
           toolchain: ${{ matrix.rust }}
           components: rustfmt
           override: true
-      - name: Check formating
+      - name: Check formatting
         uses: actions-rs/cargo@v1
         with:
           command: fmt
           args: --all -- --check
 
-  docker-api-server:
+  docker-build-and-push:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-      #- name: Login to Docker Hub
-      #  uses: docker/login-action@v2
-      #  with:
-      #    username: ${{ secrets.DOCKERHUB_USERNAME }}
-      #    password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: docker build
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push API server Docker image
         uses: docker/build-push-action@v4
         with:
-          push: false
-          tags: edgeandnode/graphix-api-server:latest
+          context: .
           file: ops/api-server.dockerfile
-  docker-cross-checker:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      #- name: Login to Docker Hub
-      #  uses: docker/login-action@v2
-      #  with:
-      #    username: ${{ secrets.DOCKERHUB_USERNAME }}
-      #    password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: docker build
+          push: true
+          tags: ghcr.io/${{ github.actor }}/graphix-api-server:latest
+      - name: Build and push cross-checker service Docker image
         uses: docker/build-push-action@v4
         with:
-          push: false
-          tags: edgeandnode/graphix-cross-checker:latest
-          file: ops/cross-checker.dockerfile
+          context: .
+          file: ops/api-server.dockerfile
+          push: true
+          tags: ghcr.io/${{ github.actor }}/graphix-cross-checker:latest
 
   build:
     name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+    if: github.ref == 'refs/heads/main'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3


### PR DESCRIPTION
I tested this on my personal fork, it should work without any changes here as well.

```
$ docker pull ghcr.io/neysofu/graphix-api-server
$ docker pull ghcr.io/neysofu/graphix-cross-checker
```

Publishes by default every time we push to `main`.