### PR TITLE
Fix Grafana permissions (remove `UID` & `GID` trickery)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Spin up the docker-compose environment
 ```sh
 cd ops/compose
 docker compose build
-UID=(id -u) GID=(id -g) docker compose up
+docker compose up
 ```
 
 Deploy at least 1 subgraph to the test graph-nodes

--- a/ops/compose/testnet-indexer.yml
+++ b/ops/compose/testnet-indexer.yml
@@ -4,7 +4,7 @@ services:
     image: grafana/grafana-enterprise
     restart: always
     # https://community.grafana.com/t/new-docker-install-with-persistent-storage-permission-problem/10896/16
-    user: "$UID:$GID"
+    user: ":"
     depends_on:
       - prometheus
     ports:

--- a/ops/compose/two-empty-graph-nodes.yml
+++ b/ops/compose/two-empty-graph-nodes.yml
@@ -4,7 +4,7 @@ services:
     image: grafana/grafana-enterprise
     restart: always
     # https://community.grafana.com/t/new-docker-install-with-persistent-storage-permission-problem/10896/16
-    user: "$UID:$GID"
+    user: ":"
     depends_on:
       - prometheus
     ports:


### PR DESCRIPTION
It looks like there is an easier way to set the right permissions for local Grafana data files.