### PR TITLE
ops: Conveniences for local testing

### DIFF
--- a/ops/compose/grafana/config/grafana.ini
+++ b/ops/compose/grafana/config/grafana.ini
@@ -1,6 +1,10 @@
-[security]
-admin_user = graphix
-admin_password = password
+[auth.anonymous]
+# Enable anonymous access
+enabled = true
+
+# Specify the role for the anonymous user; Admin role gives full permissions
+# THIS IS UNSECURE AND ONLY FOR CONVENIENCE OF LOCAL TESTING
+org_role = Admin
 
 [log.console]
 level = warn

--- a/ops/compose/network.yml
+++ b/ops/compose/network.yml
@@ -78,7 +78,7 @@ services:
   postgres-graphix:
     image: postgres
     ports:
-      - "5432:5432"
+      - "5433:5432"
     environment:
       POSTGRES_USER: graphix
       POSTGRES_PASSWORD: password


### PR DESCRIPTION
A couple changes for more convenient local testing (if others also find it convenient for their setups):
- Remove the need for login to access the local Grafana
- Bind Postgres to host 5433 port, to not conflict with a host Postgres that could be running at the default 5432.