### PR TITLE
chore(graphix-common): update indexer schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,14 @@
-ops/compose/data/*
-/target
+### IDEs
+.vscode/
+.idea/
+
+### OS
 .DS_Store
+
+### Rust
+/target
+
+### Project specific
+ops/compose/data/*
 /frontend/dist
 frontend/graphql/api_schema.graphql

--- a/backend/crates/common/graphql/indexer/schema.gql
+++ b/backend/crates/common/graphql/indexer/schema.gql
@@ -40,11 +40,17 @@ type Query {
   entityChangesInBlock(subgraphId: String!, blockNumber: Int!): EntityChanges!
   blockData(network: String!, blockHash: Bytes!): JSONObject
   blockHashFromNumber(network: String!, blockNumber: Int!): Bytes
+  version: Version!
   cachedEthereumCalls(
     network: String!
     blockHash: Bytes!
   ): [CachedEthereumCall!]
   apiVersions(subgraphId: String!): [ApiVersion!]!
+}
+
+type Version {
+  version: String!
+  commit: String!
 }
 
 type SubgraphIndexingStatus {
@@ -142,6 +148,7 @@ type SubgraphFeatures {
   specVersion: String!
   features: [Feature!]!
   dataSources: [String!]!
+  handlers: [String!]!
   network: String
 }
 


### PR DESCRIPTION
It seems that the `graph-node` schema has been updated recently. This PR updates the schema file copy checked in this repository to the one generated/downloaded by the `backend/crates/common/build.rs` build script.